### PR TITLE
Feat: Add verify staff button and hide menu checkbox

### DIFF
--- a/data/company_info.json
+++ b/data/company_info.json
@@ -1,5 +1,6 @@
 {
     "company_name": "Go Sortplux Limited",
     "logo_path": "687df4ea5c05a_go ortr.png",
-    "address": "No. 532, Rugan Juli by High Tension, City College Road, Karu"
+    "address": "No. 532, Rugan Juli by High Tension, City College Road, Karu",
+    "whatsapp_number": "+1234567890"
 }

--- a/styles.css
+++ b/styles.css
@@ -146,6 +146,10 @@ body.dark-mode .nav-menu li a {
 }
 
 /* Menu Trigger */
+.menu-toggle {
+    display: none;
+}
+
 .menu-trigger {
     position: fixed;
     top: 15px;
@@ -344,6 +348,24 @@ body.dark-mode .social-links a, body.dark-mode .contact-links a {
 
 .save-contact-btn:hover {
     background: #218838;
+    transform: scale(1.05);
+}
+
+.verify-staff-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    background: #007bff;
+    color: #fff !important;
+    padding: 0.5rem 1rem;
+    border-radius: 6px;
+    text-decoration: none;
+    font-size: 0.9rem;
+    transition: background 0.3s ease, transform 0.3s ease;
+}
+
+.verify-staff-btn:hover {
+    background: #0056b3;
     transform: scale(1.05);
 }
 

--- a/view_profile.php
+++ b/view_profile.php
@@ -20,6 +20,14 @@ if (!empty($whatsapp_number)) {
     $whatsapp_number = preg_replace('/[^0-9+]/', '', $whatsapp_number);
     $whatsapp_link = "https://wa.me/" . $whatsapp_number;
 }
+
+// Prepare staff verification link
+$company_whatsapp = $company['whatsapp_number'] ?? '';
+$verification_link = '';
+if (!empty($company_whatsapp)) {
+    $message = "Please confirm this person is your staff, " . $user['full_name'];
+    $verification_link = "https://wa.me/" . preg_replace('/[^0-9+]/', '', $company_whatsapp) . "?text=" . urlencode($message);
+}
 ?>
 <!DOCTYPE html>
 <html lang="en">
@@ -99,6 +107,11 @@ if (!empty($whatsapp_number)) {
                         <a href="mailto:<?php echo htmlspecialchars($user['email'] ?? ''); ?>"><i class="fas fa-envelope"></i></a>
                         <a href="tel:<?php echo htmlspecialchars($user['phone_number'] ?? ''); ?>"><i class="fas fa-phone"></i></a>
                         <button class="save-contact-btn" onclick="saveContact()">Save Contact</button>
+                        <?php if (!empty($verification_link)) : ?>
+                            <a href="<?php echo htmlspecialchars($verification_link); ?>" target="_blank" class="verify-staff-btn">
+                                <i class="fas fa-user-check"></i> Verify Staff
+                            </a>
+                        <?php endif; ?>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
This commit introduces two main changes:

1. A "Verify Staff" button has been added to the user profile page. This button opens a pre-filled WhatsApp message to a dedicated company number, allowing visitors to verify the staff member's employment. The company's WhatsApp number is now stored in `data/company_info.json`.

2. The checkbox used for the hamburger menu is now hidden via CSS to improve the user interface.