### PR TITLE
Fix: Resolve overlap between Verify and Save Contact buttons

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -335,6 +335,10 @@ body.dark-mode .social-links a, body.dark-mode .contact-links a {
     pointer-events: none;
 }
 
+.contact-links > * {
+    flex-shrink: 0; /* Prevent items from shrinking, force them to wrap */
+}
+
 .save-contact-btn {
     background: #28a745;
     color: #fff !important; /* Ensure text is visible */


### PR DESCRIPTION
On the profile page, the "Verify Staff" button was overlapping the "Save Contact" button on certain screen sizes. This was caused by the flex items shrinking in an undesirable way.

This change adds `flex-shrink: 0` to the children of the `.contact-links` container. This prevents the items from shrinking and forces them to wrap to the next line when there is not enough space, which correctly resolves the overlap issue.