### PR TITLE
Style: Make Verify Staff button a square icon button

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -335,10 +335,6 @@ body.dark-mode .social-links a, body.dark-mode .contact-links a {
     pointer-events: none;
 }
 
-.contact-links > * {
-    flex-shrink: 0; /* Prevent items from shrinking, force them to wrap */
-}
-
 .save-contact-btn {
     background: #28a745;
     color: #fff !important; /* Ensure text is visible */
@@ -358,14 +354,15 @@ body.dark-mode .social-links a, body.dark-mode .contact-links a {
 .verify-staff-btn {
     display: inline-flex;
     align-items: center;
-    gap: 0.75rem;
     background: #007bff;
     color: #fff !important;
-    padding: 0.5rem 1rem;
     border-radius: 6px;
     text-decoration: none;
-    font-size: 0.9rem;
     transition: background 0.3s ease, transform 0.3s ease;
+    padding: 0;
+    width: 40px;
+    height: 40px;
+    justify-content: center;
 }
 
 .verify-staff-btn:hover {
@@ -385,7 +382,7 @@ body.dark-mode .social-links a, body.dark-mode .contact-links a {
 }
 
 .verify-staff-btn .text {
-    font-weight: 600;
+    display: none;
 }
 
 /* Tabbed Content */
@@ -950,15 +947,6 @@ body.light-mode .footer {
         width: 40px;
         height: 40px;
         font-size: 1.2rem;
-    }
-    .verify-staff-btn .text {
-        display: none;
-    }
-    .verify-staff-btn {
-        padding: 0;
-        width: 40px;
-        height: 40px;
-        justify-content: center;
     }
 }
 


### PR DESCRIPTION
Based on user feedback, the "Verify Staff" button has been restyled to be a square icon button on all screen sizes, similar to its appearance on mobile.

This change involves:
- Making the button a 40x40 square.
- Hiding the "Verify Staff" text.
- Applying these styles globally and removing the mobile-specific media query for this button.

This resolves the previous layout issues and aligns the button's appearance with the user's request.